### PR TITLE
Bug_fix, second GameManager calling null

### DIFF
--- a/Assets/Scripts/Main/GameManager.cs
+++ b/Assets/Scripts/Main/GameManager.cs
@@ -149,11 +149,19 @@ namespace Main
         //----------------------
         private void OnEnable()
         {
+            if (Instance != this)
+            {
+                return;
+            }
             SceneManager.sceneLoaded += OnSceneLoad;
         }
 
         private void OnDisable()
         {
+            if (Instance != this)
+            {
+                return;
+            }
             SceneManager.sceneLoaded += OnSceneLoad;
         }
 


### PR DESCRIPTION
Fixed a bug when you enter a new scene and the GameManager to be removed can still subscribe to sceneLoaded event, causing a bug when trying to call a function from _uIManager, which is null